### PR TITLE
Delete .gitlab-ci.yml

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -13,17 +13,11 @@ on:
         required: false
         type: string
         default: "document"
-    #outputs:
-    #  pdf_path:
-    #    description: "Path to the compiled PDF files"
-    #    value: ${{ jobs.build-latex.outputs.pdf_path }}
 
 jobs:
   build-latex:
     runs-on: ubuntu-latest
     name: Compile LaTeX Document
-    #outputs:
-    #  pdf_path: "${{ inputs.working-directory }}/compiled"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy GitLab CI pipeline configuration used for linting, building, releasing, and syncing.
  * Streamlines internal build/release processes without altering application functionality or interfaces.
  * No changes to features, performance, or user workflows.
  * Deployments and automation are now managed through updated internal processes.
  * No action required from end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->